### PR TITLE
Update grammar for `define`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -605,7 +605,7 @@ module.exports = grammar({
           seq($.identifier, "=", $._path),
           seq($.identifier, "=", $._path, $.type_parameters),
           seq($.type_identifier, "=", optional("distinct"), $._type),
-          seq($.type_identifier, "=", $._type_path, $.type_parameters),
+          seq($.type_identifier, "=", $._type_path, optional("("), $.type_parameters, optional(")")),
           seq($.type_identifier, "=", $.function_pointer_type)
         ),
         ";"

--- a/grammar.js
+++ b/grammar.js
@@ -600,7 +600,7 @@ module.exports = grammar({
 
     define_declaration: ($) =>
       seq(
-        "define",
+        "def",
         choice(
           seq($.identifier, "=", $._path),
           seq($.identifier, "=", $._path, $.type_parameters),


### PR DESCRIPTION
`Define` keyword has been changed to `def`: https://c3-lang.org/define/

Also made a change (not sure about this) to support type definitions with generics.
Example:

```
def Features = HashMap(<String, Feature>);
```

Feel free to suggest a better approach for this last one.